### PR TITLE
QuickFix for VS v143 Toolchain build errors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 *.lo
 *.o
 *.obj
+*.cso
 
 # Precompiled Headers
 *.gch
@@ -27,7 +28,7 @@
 #*.lib
 
 # Executables
-#*.exe
+*.exe
 #*.out
 #*.app
 

--- a/.gitignore
+++ b/.gitignore
@@ -28,7 +28,7 @@
 #*.lib
 
 # Executables
-*.exe
+#*.exe
 #*.out
 #*.app
 

--- a/Source/Framework/Misc/RNG.cpp
+++ b/Source/Framework/Misc/RNG.cpp
@@ -29,77 +29,77 @@ void RNG::seed()
 
 bool RNG::coin_toss()
 {
-    const std::bernoulli_distribution dist;
+    std::bernoulli_distribution dist;
 
     return dist(generator);
 }
 
 unsigned RNG::d2()
 {
-    const std::uniform_int_distribution<unsigned> dist(1, 2);
+    std::uniform_int_distribution<unsigned> dist(1, 2);
     
     return dist(generator);
 }
 
 unsigned RNG::d3()
 {
-    const std::uniform_int_distribution<unsigned> dist(1, 3);
+    std::uniform_int_distribution<unsigned> dist(1, 3);
 
     return dist(generator);
 }
 
 unsigned RNG::d4()
 {
-    const std::uniform_int_distribution<unsigned> dist(1, 4);
+    std::uniform_int_distribution<unsigned> dist(1, 4);
 
     return dist(generator);
 }
 
 unsigned RNG::d6()
 {
-    const std::uniform_int_distribution<unsigned> dist(1, 6);
+    std::uniform_int_distribution<unsigned> dist(1, 6);
 
     return dist(generator);
 }
 
 unsigned RNG::d8()
 {
-    const std::uniform_int_distribution<unsigned> dist(1, 8);
+    std::uniform_int_distribution<unsigned> dist(1, 8);
 
     return dist(generator);
 }
 
 unsigned RNG::d10()
 {
-    const std::uniform_int_distribution<unsigned> dist(1, 10);
+    std::uniform_int_distribution<unsigned> dist(1, 10);
 
     return dist(generator);
 }
 
 unsigned RNG::d12()
 {
-    const std::uniform_int_distribution<unsigned> dist(1, 12);
+    std::uniform_int_distribution<unsigned> dist(1, 12);
 
     return dist(generator);
 }
 
 unsigned RNG::d20()
 {
-    const std::uniform_int_distribution<unsigned> dist(1, 20);
+    std::uniform_int_distribution<unsigned> dist(1, 20);
 
     return dist(generator);
 }
 
 unsigned RNG::d100()
 {
-    const std::uniform_int_distribution<unsigned> dist(1, 100);
+    std::uniform_int_distribution<unsigned> dist(1, 100);
 
     return dist(generator);
 }
 
 Vec2 RNG::unit_vector_2D()
 {
-    const std::uniform_real_distribution<float> dist(0.0f, PI);
+    std::uniform_real_distribution<float> dist(0.0f, PI);
 
     const float azimuth = dist(generator);
 
@@ -108,7 +108,7 @@ Vec2 RNG::unit_vector_2D()
 
 Vec3 RNG::unit_vector_3D()
 {
-    const std::uniform_real_distribution<float> dist(-1.0f, 1.0f);
+    std::uniform_real_distribution<float> dist(-1.0f, 1.0f);
 
     const float z = dist(generator);
 
@@ -119,14 +119,14 @@ Vec3 RNG::unit_vector_3D()
 
 Color RNG::color(float alpha)
 {
-    const std::uniform_real_distribution<float> dist(0.0f, 1.0f);
+    std::uniform_real_distribution<float> dist(0.0f, 1.0f);
 
     return Color(dist(generator), dist(generator), dist(generator), alpha);
 }
 
 Vec3 RNG::world_position()
 {
-    const std::uniform_real_distribution<float> dist(0.0f, terrain->mapSizeInWorld);
+    std::uniform_real_distribution<float> dist(0.0f, terrain->mapSizeInWorld);
     
     return Vec3(dist(generator), 0.0f, dist(generator));
 }

--- a/Source/Framework/Misc/RNG.h
+++ b/Source/Framework/Misc/RNG.h
@@ -79,7 +79,7 @@ inline std::enable_if_t<std::is_integral<T>::value, T> RNG::typed_range(T min, T
     using Type = std::uniform_int_distribution<T>;
 
     // guard against flipped values, or negative value confusion
-    const Type dist = (min < max) ? Type(min, max) : Type(max, min);
+    Type dist = (min < max) ? Type(min, max) : Type(max, min);
 
     return dist(generator);
 }
@@ -90,7 +90,7 @@ inline std::enable_if_t<std::is_floating_point<T>::value, T> RNG::typed_range(T 
     using Type = std::uniform_real_distribution<T>;
 
     // guard against flipped values, or negative value confusion
-    const Type dist = (min < max) ? Type(min, max) : Type(max, min);
+    Type dist = (min < max) ? Type(min, max) : Type(max, min);
 
     return dist(generator);
 }


### PR DESCRIPTION
This file now causes build errors, as of the new VS v143 Toolchain (VS2022).

There is no logical reason that an RNG or anything dependent on a random stream should be const.